### PR TITLE
Added optional 'category' for hotkeys. When displaying the cheatsheet…

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ angular.module('myApp', ['cfp.hotkeys'])
 - `callback`: The function to execute when the key(s) are pressed.  Passes along two arguments, `event` and `hotkey`
 - `action`: [OPTIONAL] The type of event to listen for, such as `keypress`, `keydown` or `keyup`. Usage of this parameter is discouraged as the underlying library will pick the most suitable option automatically. This should only be necessary in advanced situations.
 - `allowIn`: [OPTIONAL] an array of tag names to allow this combo in ('INPUT', 'SELECT', and/or 'TEXTAREA')
+- `category`: [OPTIONAL] A category name that the shortcut will be grouped under.
 
 ```js
 hotkeys.add({

--- a/src/hotkeys.css
+++ b/src/hotkeys.css
@@ -32,6 +32,12 @@
   font-size: 1.2em;
 }
 
+.cfp-hotkeys-category-title {
+  font-weight: bold;
+  font-size: 1.0em;
+  padding: 14px 0 10px 70px;
+}
+
 .cfp-hotkeys {
   width: 100%;
   height: 100%;
@@ -39,9 +45,28 @@
   vertical-align: middle;
 }
 
+.cfp-hotkeys-category-container {
+  margin: 0 auto;
+  display: table;
+}
+
+.cfp-hotkeys-category-container:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
 .cfp-hotkeys table {
-  margin: auto;
+  margin: 0 25px 0 0;
   color: #333;
+  float: left;
+  width: 300px;
+}
+
+.cfp-hotkeys-category-container table:nth-child(2n+3) {
+  content: "";
+  display: table;
+  clear: both;
 }
 
 .cfp-content {
@@ -52,6 +77,7 @@
 .cfp-hotkeys-keys {
   padding: 5px;
   text-align: right;
+  width: 45%;
 }
 
 .cfp-hotkeys-key {


### PR DESCRIPTION
…, the hotkeys are shown per category in a 2 column layout. If no category is specified for a hotkey, the hotkey defaults to a configurable default category. If no hotkeys have a category, the cheatsheet looks just like it used to.